### PR TITLE
replace tags with images host and scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ Where `user_id` is the id of the authenticated user.
 The `user_id` should be a non-blank String or a non-zero integer. When no
 user is authenticated, it should be set to `nil`.
 
+Use `replace_sticker_tags` to replace a string message that contains sticker tags (`[s:PATH]`) into HTML `<img>` tags
+
+```rb
+Feeligo::Stickers.replace_sticker_tags(string, opts)
+```
+
+> By default images are hosted over `HTTP` at `stkr.es`
+> if available, you can override either the scheme or host domain or both settings using the opts parameter
+
+```rb
+# src: https://flg.stkr.fr/PATH
+opts = {scheme: 'https', host: 'flg.stkr.fr'}
+```
+
+
 
 ## Contributing
 

--- a/lib/feeligo/stickers.rb
+++ b/lib/feeligo/stickers.rb
@@ -5,7 +5,7 @@ require "feeligo/stickers/sticker_image_tag"
 
 module Feeligo
   module Stickers
-    
+
     # Returns a <script> tag which can be added to a View to load the Feeligo
     # Stickers module.
     # The <script> tag should be inserted right after the opening <body> tag

--- a/lib/feeligo/stickers/sticker_image_tag.rb
+++ b/lib/feeligo/stickers/sticker_image_tag.rb
@@ -39,17 +39,32 @@ protected
     attrs = {}
     @opts.each_pair{|k, v| attrs[k.to_s] = v.to_s}
     attrs["src"] = image_url
-    attrs
+    attrs.reject{|k,v| %w(host scheme).include? k.to_s}
   end
 
 
   # The URL of the image
   def image_url
     return "" if @path.nil? || @path.empty?
-    "http://stkr.es/" << if m = /^(p3w|p7s|p)\/(.*)$/.match(@path)
+    "#{images_scheme}://#{images_host}/" << if m = /^(pv4|pfk|p7s|p6o|p3w|p7s|p)\/(.*)$/.match(@path)
       "p/" << m[2]
     else
       @path
+    end
+  end
+
+
+  def images_scheme
+    @opts[:scheme] || "http"
+  end
+
+
+  def images_host
+    return @opts[:host] if @opts[:host]
+    if @opts[:scheme] == "https"
+      "ssl.stkr.es"
+    else
+      "stkr.es"
     end
   end
 

--- a/lib/feeligo/stickers/version.rb
+++ b/lib/feeligo/stickers/version.rb
@@ -1,5 +1,5 @@
 module Feeligo
   module Stickers
-    VERSION = "0.1.3"
+    VERSION = "0.1.4"
   end
 end

--- a/spec/feeligo/stickers_spec.rb
+++ b/spec/feeligo/stickers_spec.rb
@@ -106,6 +106,30 @@ describe Feeligo::Stickers do
       let(:string){"Hello [s:] world"}
       it_behaves_like "with no tags"
     end
+    context "when the images scheme is overriden" do
+      let(:opts){{scheme: 'https'}}
+      let(:string){"Hello [s:PATH] world"}
+      it "correctly replaces the tag" do
+        expect(Feeligo::Stickers.replace_sticker_tags(string, opts)).to eq(
+          'Hello <img src="https://ssl.stkr.es/PATH"/> world')
+      end
+    end
+    context "when the images host is overriden" do
+      let(:opts){{host: 'flg.stkr.fr'}}
+      let(:string){"Hello [s:PATH] world"}
+      it "correctly replaces the tag" do
+        expect(Feeligo::Stickers.replace_sticker_tags(string, opts)).to eq(
+          'Hello <img src="http://flg.stkr.fr/PATH"/> world')
+      end
+    end
+    context "when both the images host and scheme are overriden" do
+      let(:opts){{host: 'flg.stkr.fr', scheme: 'https'}}
+      let(:string){"Hello [s:PATH] world"}
+      it "correctly replaces the tag" do
+        expect(Feeligo::Stickers.replace_sticker_tags(string, opts)).to eq(
+          'Hello <img src="https://flg.stkr.fr/PATH"/> world')
+      end
+    end
   end
 
 end


### PR DESCRIPTION
The idea is to give some control of the URLs hosting Sticker assets rather than the default `http://stkr.es`

I suggest using the `opts` parameter with `scheme` and `host` keys to override the `image_url`.
